### PR TITLE
refactor(cli): let yargs lookup the version number

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,6 +7,6 @@ var argv = require('yargs')
 	.command(require('./commands/ls'))
 	.command(require('./commands/set'))
 	.command(require('./commands/del'))
-	.version(function() { return require('./package').version; })
-	.help('help')
+	.version()
+	.help()
 	.argv;


### PR DESCRIPTION
Note that `npm run lint` and `npm test` both currently fail. This does nothing to address that.
