### PR TITLE
feat: add grep <pattern> command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,8 @@ var yargs = require('yargs')
 	.option('env', {
 		alias: 'e',
 		description: 'which etcd host group to use',
-		default: 'default'
+		default: 'default',
+		global: true
 	})
 	.version()
 	.help()

--- a/commands/grep.js
+++ b/commands/grep.js
@@ -1,0 +1,56 @@
+var
+	chalk       = require('chalk'),
+	furthermore = require('../index'),
+	visit       = require('visit-values')
+	;
+
+function builder(yargs)
+{
+	return yargs.demand(2, 'need a pattern to grep for e.g. foo or /foo/');
+}
+
+function handler(argv)
+{
+	furthermore.setConfig(argv.env);
+
+	var pattern = argv.pattern;
+
+	if (/^\/.*\/$/.test(argv.pattern))
+		pattern = pattern.replace(/^\/(.*)\/$/, '$1');
+
+	var regexp = new RegExp(pattern);
+
+	furthermore.all(function(err, all)
+	{
+		if (err)
+			return console.log(chalk.red('error: ') + err.message);
+
+		var lines = [];
+
+		visit(all, function(value, key, parent)
+		{
+			if (regexp.test(value))
+			{
+				lines.push(chalk.bold(key) + chalk.yellow(' == ') + chalk.blue(value));
+			}
+		});
+
+		if (lines.length)
+		{
+			lines.sort();
+			console.log(chalk.bold(pattern) + chalk.yellow(' matches:'));
+			console.log(lines.join('\n'));
+		}
+		else
+		{
+			console.log(chalk.bold(pattern) + chalk.yellow(' has no matches.'));
+		}
+	});
+}
+
+module.exports = {
+	command: 'grep <pattern>',
+	describe: 'search for values matching the given regexp pattern',
+	builder: builder,
+	handler: handler
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "rc": "~1.1.6",
     "require-directory": "~2.1.1",
     "update-notifier": "~0.6.3",
+    "visit-values": "^1.0.4",
     "yargs": "~4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #4.

Allows you to do `fm grep foo` or `fm grep /foo/`, finds values matching the pattern, and spits out the keys and values found, in similar fashion to `fm get /foo/` (but matching against values instead of keys).

Still needs tests.

This could possibly be implemented as an option on the `get /foo/` command instead of as a whole 'nother command. Feedback welcomed.

Also it works well for values not nested in directories, but haven't tested it when nested dirs are used. It will find nested values ok, it just probably won't print the right keys.
