### PR TITLE
fix(grep): yargs.demand() is now command-aware

### DIFF
--- a/commands/grep.js
+++ b/commands/grep.js
@@ -6,7 +6,7 @@ var
 
 function builder(yargs)
 {
-	return yargs.demand(2, 'need a pattern to grep for e.g. foo or /foo/');
+	return yargs.demand(1, 'need a pattern to grep for e.g. foo or /foo/');
 }
 
 function handler(argv)


### PR DESCRIPTION
Since the upgrade to yargs 5, we no longer need to account for the command itself when demanding a certain number of flagless args. (See yargs/yargs#582)

This fixes the `fm grep` command so that it only requires one additional arg to the command.

Without this change:

``` console
$ fm grep foo
fm grep <pattern>

Options:
  --env, -e  which etcd host group to use                   [default: "default"]
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]

need a pattern to grep for e.g. foo or /foo/
```

With this change:

``` console
$ fm grep foo
foo has no matches.
```
