### PR TITLE
feat: recommend commands, print help sans args

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var updater = require('update-notifier'),
 
 updater({pkg: pkg}).notify();
 
-var yargs = require('yargs')
+require('yargs')
 	.usage('furthermore: manipulate keys on a remote etcd server')
 	.example('furthermore ls /deploys')
 	.example('furthermore mkdir /deploys/website')
@@ -20,12 +20,10 @@ var yargs = require('yargs')
 		default: 'default',
 		global: true
 	})
+	.commandDir('commands')
+	.recommendCommands()
+	.demand(1, 'Need a command. Choose from our fine selection above.')
 	.version()
 	.help()
+	.argv
 	;
-
-var requireDirectory = require('require-directory'),
-	commands = requireDirectory(module, './commands');
-Object.keys(commands).forEach(function(c) { yargs.command(commands[c]); });
-
-yargs.argv;

--- a/package.json
+++ b/package.json
@@ -13,10 +13,8 @@
   "dependencies": {
     "chalk": "~1.1.3",
     "cli-columns": "~1.0.6",
-    "lodash.map": "~4.6.0",
     "node-etcd": "~5.0.3",
     "rc": "~1.1.6",
-    "require-directory": "~2.1.1",
     "update-notifier": "~1.0.2",
     "visit-values": "^1.0.4",
     "yargs": "~5.0.0"


### PR DESCRIPTION
Some minor improvements:
1. Let yargs 5 recommend commands if an unknown command is given
2. Print help/usage text (with friendly message) when run with no command/args
3. Replace explicit use of `require-directory` with `yargs.commandDir('commands')` (identical functionality)
4. Drop deps no longer used
