### PR TITLE
feat: add --raw option for get command

### DIFF
--- a/commands/get.js
+++ b/commands/get.js
@@ -4,7 +4,14 @@ var
 	furthermore = require('../index')
 	;
 
-function builder() {}
+function builder(yargs)
+{
+	return yargs.option('raw', {
+		alias: 'r',
+		desc: 'Write just the raw value to stdout?',
+		type: 'boolean'
+	});
+}
 
 function getMatch(key)
 {
@@ -51,7 +58,16 @@ function handler(argv)
 			console.log(columns(children));
 		}
 		else
-			console.log(chalk.bold(results.key) + chalk.yellow(' == ') + chalk.blue(results.value));
+		{
+			if (argv.raw)
+			{
+				process.stdout.write(results.value);
+			}
+			else
+			{
+				console.log(chalk.bold(results.key) + chalk.yellow(' == ') + chalk.blue(results.value));
+			}
+		}
 	});
 }
 


### PR DESCRIPTION
Useful for piping JSON values to a parser e.g. `fm get key -r | json`

Considerations:
1. A `--json` flag would possibly remove the need to pipe the output to a parser, but a parser is probably gonna have a lot more functionality than furthermore should care about
2. I opted for `process.stdout.write` instead of `console.log` to avoid tacking on the line feed to the value. This may or may not be desirable.
3. Would `--raw` be useful for other commands? Maybe, but I figured to start small and expand later if necessary.
