### PR TITLE
refactor: replace `node-etcd` with `etcdjs`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var
-	chalk = require('chalk'),
-	Etcd  = require('node-etcd'),
-	rc    = require('rc')('etcd', { hosts: '127.0.0.1:4001', ssl: false }, []),
+	chalk  = require('chalk'),
+	etcdjs = require('etcdjs'),
+	rc     = require('rc')('etcd', { hosts: '127.0.0.1:4001', ssl: false }, []),
 	etcd
 	;
 
@@ -14,7 +14,7 @@ exports.setConfig = function setConfig(env)
 		return (configset.ssl ? 'https://' : 'http://') + h;
 	});
 
-	etcd = new Etcd(configset.hosts);
+	etcd = etcdjs(configset.hosts);
 	exports.etcd = etcd;
 };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "chalk": "~1.1.3",
     "cli-columns": "~3.0.0",
-    "node-etcd": "~5.0.3",
+    "etcdjs": "^2.4.2",
     "rc": "~1.2.1",
     "update-notifier": "~2.1.0",
     "visit-values": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 
 var
 	demand      = require('must'),
-	Etcd        = require('node-etcd'),
+	etcdjs      = require('etcdjs'),
 	sinon       = require('sinon'),
 	furthermore = require('./index')
 	;
@@ -27,7 +27,7 @@ describe('furthermore', () =>
 		demand(furthermore.etcd).be.undefined();
 		furthermore.setConfig();
 		furthermore.etcd.must.be.an.object();
-		furthermore.etcd.must.be.instanceof(Etcd);
+		furthermore.etcd.must.be.instanceof(etcdjs);
 	});
 
 	it('rm() calls etcd.del()', done =>


### PR DESCRIPTION
`node-etcd` uses a compiled module for functionality we don't even want.
Replace it with `etcdjs` instead.