### PR TITLE
Fix/grep

### DIFF
--- a/commands/grep.js
+++ b/commands/grep.js
@@ -4,10 +4,7 @@ var
 	visit       = require('visit-values')
 	;
 
-function builder(yargs)
-{
-	return yargs.demand(1, 'need a pattern to grep for e.g. foo or /foo/');
-}
+function builder(yargs) {}
 
 function handler(argv)
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "furthermore",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "furthermore",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -14,6 +15,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -26,7 +30,11 @@
     "ajv": {
       "version": "4.11.7",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
-      "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg="
+      "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg=",
+      "requires": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -38,16 +46,27 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
       "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "requires": {
+        "string-width": "^1.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -71,7 +90,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "array-differ": {
       "version": "1.0.0",
@@ -89,7 +111,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -129,7 +154,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -141,23 +171,42 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "boxen": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
-      "integrity": "sha1-smlLrx9gX3CP8Bd8Ehk7IvKaqqs="
+      "integrity": "sha1-smlLrx9gX3CP8Bd8Ehk7IvKaqqs=",
+      "requires": {
+        "ansi-align": "^1.1.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^1.1.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^0.1.0",
+        "widest-line": "^1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.1",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -186,7 +235,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -204,6 +256,10 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -227,7 +283,14 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -243,13 +306,20 @@
     "cli-columns": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.0.0.tgz",
-      "integrity": "sha1-0mJuDz4vNI30RAetPkk3oqvO0xc="
+      "integrity": "sha1-0mJuDz4vNI30RAetPkk3oqvO0xc=",
+      "requires": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      }
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -261,16 +331,29 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -287,13 +370,19 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -306,25 +395,50 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "string_decoder": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
           "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "~1.0.0"
+          }
         }
       }
     },
     "configstore": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
-      "integrity": "sha1-4bhmnBgDzMULVF6S+ObnmqgOAZY="
+      "integrity": "sha1-4bhmnBgDzMULVF6S+ObnmqgOAZY=",
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^1.1.2",
+        "xdg-basedir": "^3.0.0"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -336,7 +450,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      }
     },
     "core-js": {
       "version": "2.4.1",
@@ -354,27 +472,48 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
     },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
     },
     "cross-spawn-async": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw="
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+      "requires": {
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.x.x"
+      }
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -385,18 +524,27 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -409,7 +557,10 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "0.7.2"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -420,7 +571,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.4.1",
@@ -437,19 +591,39 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
       "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-assert": "^0.2.0"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      },
       "dependencies": {
         "globby": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
         }
       }
     },
@@ -468,12 +642,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
     },
     "dot-prop": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE="
+      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -484,60 +665,106 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "egal": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/egal/-/egal-1.3.0.tgz",
       "integrity": "sha1-IKGc+oDOlzP4QTY10AQmQfQpGHs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kindof": ">= 2.0.0 < 3"
+      }
     },
     "enhance-visitors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
       "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "^4.13.1"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.15",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
       "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2",
+        "es6-symbol": "~3.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-symbol": "^3.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -548,13 +775,56 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -580,25 +850,44 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.1.0.tgz",
       "integrity": "sha1-q00G2gL+2ME66fDcVApDPvftb14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.4.0",
+        "chalk": "^1.1.3",
+        "log-symbols": "^1.0.2",
+        "plur": "^2.1.2",
+        "string-width": "^2.0.0"
+      }
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
+      }
     },
     "eslint-module-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
       "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "pkg-dir": "^1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -612,19 +901,45 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.2.0.tgz",
       "integrity": "sha1-EuRmRlnB+ueJX6PzRsMTzriQfHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "deep-strict-equal": "^0.2.0",
+        "enhance-visitors": "^1.0.0",
+        "espree": "^3.1.3",
+        "espurify": "^1.5.0",
+        "multimatch": "^2.1.0",
+        "pkg-up": "^1.0.0",
+        "req-all": "^1.0.0"
+      }
     },
     "eslint-plugin-import": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
+      "requires": {
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.2.0",
+        "eslint-module-utils": "^2.0.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "pkg-up": "^1.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
         }
       }
     },
@@ -632,7 +947,13 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
       "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-get-set-prop": "^1.0.0",
+        "is-js-type": "^2.0.0",
+        "is-obj-prop": "^1.0.0",
+        "is-proto-prop": "^1.0.0"
+      }
     },
     "eslint-plugin-promise": {
       "version": "3.5.0",
@@ -644,13 +965,24 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.1.tgz",
       "integrity": "sha1-PpKUNmeZtxXham34kVlJW2iTDLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.camelcase": "^4.1.1",
+        "lodash.kebabcase": "^4.0.1",
+        "lodash.snakecase": "^4.0.1",
+        "lodash.upperfirst": "^4.2.0",
+        "req-all": "^1.0.0"
+      }
     },
     "espree": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
       "integrity": "sha1-ONve2+3JW4lhofvwRzSo9qnIxZI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.1",
+        "acorn-jsx": "^3.0.0"
+      }
     },
     "esprima": {
       "version": "2.7.3",
@@ -662,19 +994,29 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0"
+      }
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
     },
     "esrecurse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "~4.1.0",
+        "object-assign": "^4.0.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -700,6 +1042,10 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/etcdjs/-/etcdjs-2.4.2.tgz",
       "integrity": "sha1-zZuns1VF7ZBB1Kq1Rb1kvh+B2dE=",
+      "requires": {
+        "request": "2.81.0",
+        "roundround": "0.2.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
@@ -719,17 +1065,31 @@
         "form-data": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "har-validator": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "qs": {
           "version": "6.4.0",
@@ -739,12 +1099,39 @@
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
         "uuid": {
           "version": "3.0.1",
@@ -757,12 +1144,24 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "execa": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M="
+      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+      "requires": {
+        "cross-spawn-async": "^2.1.1",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "path-key": "^1.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -790,25 +1189,43 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -819,13 +1236,21 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
     },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.x"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -849,7 +1274,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -877,6 +1305,9 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -889,7 +1320,15 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "globals": {
       "version": "9.17.0",
@@ -901,12 +1340,32 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA="
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -934,18 +1393,30 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.0.2"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -956,7 +1427,13 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -972,7 +1449,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "ignore": {
       "version": "3.2.7",
@@ -989,13 +1471,20 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1013,18 +1502,41 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -1053,7 +1565,10 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
     },
     "is-error": {
       "version": "2.2.1",
@@ -1065,7 +1580,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1076,19 +1594,32 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
       "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-set-props": "^0.1.0",
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
       "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-types": "^1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -1104,7 +1635,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
       "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0",
+        "obj-props": "^1.0.0"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1116,13 +1651,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -1140,7 +1681,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-1.0.0.tgz",
       "integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0",
+        "proto-props": "^0.2.0"
+      }
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -1151,7 +1696,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "^1.0.1"
+      }
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -1194,7 +1742,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -1212,7 +1763,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1228,7 +1783,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1256,6 +1814,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1273,7 +1837,10 @@
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU="
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "requires": {
+        "package-json": "^4.0.0"
+      }
     },
     "lazy-req": {
       "version": "2.0.0",
@@ -1283,7 +1850,10 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "lcov-parse": {
       "version": "0.0.10",
@@ -1295,18 +1865,33 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -1325,7 +1910,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -1343,7 +1932,10 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
       "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -1379,7 +1971,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -1409,7 +2006,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.snakecase": {
       "version": "4.1.1",
@@ -1427,7 +2029,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.wrap/-/lodash.wrap-3.0.1.tgz",
       "integrity": "sha1-P82L74Z7LsjCG6xjjYFhgFk/cas=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._createwrapper": "^3.0.0"
+      }
     },
     "log-driver": {
       "version": "1.2.5",
@@ -1439,7 +2044,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0"
+      }
     },
     "lolex": {
       "version": "1.6.0",
@@ -1451,7 +2059,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -1461,7 +2073,11 @@
     "lru-cache": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "requires": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
     },
     "map-obj": {
       "version": "1.0.1",
@@ -1472,13 +2088,28 @@
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
     },
     "mime-db": {
       "version": "1.27.0",
@@ -1488,7 +2119,10 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "~1.27.0"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -1499,7 +2133,10 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.0.0"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -1510,6 +2147,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -1523,12 +2163,28 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         }
       }
     },
@@ -1542,13 +2198,26 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
     },
     "must": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/must/-/must-0.13.4.tgz",
       "integrity": "sha1-nROJ9FjolLKqBAMr/rekBxT3gXE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "egal": ">= 1.3.0 < 2",
+        "json-stringify-safe": ">= 5 < 6",
+        "kindof": ">= 2.0.0 < 3",
+        "lodash.wrap": ">= 3 < 4",
+        "oolong": ">= 1.11.0 < 2"
+      }
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -1571,12 +2240,21 @@
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
     },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8="
+      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+      "requires": {
+        "path-key": "^1.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1588,11 +2266,46 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.1.tgz",
       "integrity": "sha512-gEoyBAJELKCVbmQWDfeO/w9hb8dXLsxUvWUF4MKv3vJ9zsJt5C2fvKV7nTVOmZCDrP+1+xkr9tzMDccnoeih/A==",
       "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.0.7",
+        "istanbul-lib-instrument": "^1.7.2",
+        "istanbul-lib-report": "^1.1.1",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "istanbul-reports": "^1.1.1",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "1.2.4",
+        "test-exclude": "^4.1.1",
+        "yargs": "^8.0.1",
+        "yargs-parser": "^5.0.0"
+      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
         },
         "amdefine": {
           "version": "1.0.1",
@@ -1612,7 +2325,10 @@
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
         },
         "archy": {
           "version": "1.0.0",
@@ -1622,7 +2338,10 @@
         "arr-diff": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
         },
         "arr-flatten": {
           "version": "1.0.3",
@@ -1647,37 +2366,83 @@
         "babel-code-frame": {
           "version": "6.22.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
         },
         "babel-generator": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
         },
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
         },
         "babel-runtime": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
+          }
         },
         "babel-template": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1",
+            "babylon": "^6.11.0",
+            "lodash": "^4.2.0"
+          }
         },
         "babel-traverse": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.22.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1",
+            "babylon": "^6.15.0",
+            "debug": "^2.2.0",
+            "globals": "^9.0.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          }
         },
         "babel-types": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
+          }
         },
         "babylon": {
           "version": "6.17.2",
@@ -1692,12 +2457,21 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "^0.4.1",
+            "concat-map": "0.0.1"
+          }
         },
         "braces": {
           "version": "1.8.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -1707,7 +2481,12 @@
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
+          }
         },
         "camelcase": {
           "version": "1.2.1",
@@ -1719,18 +2498,34 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
         },
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -1768,12 +2563,19 @@
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
         },
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "debug-log": {
           "version": "1.0.1",
@@ -1788,17 +2590,26 @@
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
         },
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -1813,22 +2624,40 @@
         "execa": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
         },
         "expand-brackets": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
         },
         "expand-range": {
           "version": "1.8.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
         },
         "extglob": {
           "version": "0.3.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
         },
         "filename-regex": {
           "version": "2.0.1",
@@ -1838,17 +2667,32 @@
         "fill-range": {
           "version": "2.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
         },
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
+          }
         },
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "for-in": {
           "version": "1.0.2",
@@ -1858,12 +2702,19 @@
         "for-own": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1878,22 +2729,41 @@
         "get-stream": {
           "version": "2.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "glob-base": {
           "version": "0.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
         },
         "globals": {
           "version": "9.17.0",
@@ -1909,18 +2779,30 @@
           "version": "4.0.10",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -1940,7 +2822,11 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1950,7 +2836,10 @@
         "invariant": {
           "version": "2.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -1970,7 +2859,10 @@
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
         },
         "is-dotfile": {
           "version": "1.0.3",
@@ -1980,7 +2872,10 @@
         "is-equal-shallow": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -1995,22 +2890,34 @@
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
         },
         "is-number": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -2045,7 +2952,10 @@
         "isobject": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
@@ -2055,34 +2965,65 @@
         "istanbul-lib-hook": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
         },
         "istanbul-lib-instrument": {
           "version": "1.7.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.13.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "semver": "^5.3.0"
+          }
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.3",
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          }
         },
         "istanbul-reports": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
         },
         "js-tokens": {
           "version": "3.0.1",
@@ -2097,7 +3038,10 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -2108,17 +3052,31 @@
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
         },
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
@@ -2135,22 +3093,33 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
         },
         "lru-cache": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
         },
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
         },
         "md5-o-matic": {
           "version": "0.1.1",
@@ -2160,17 +3129,38 @@
         "mem": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
         },
         "merge-source-map": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.3"
+          }
         },
         "micromatch": {
           "version": "2.3.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
         },
         "mimic-fn": {
           "version": "1.1.0",
@@ -2180,7 +3170,10 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -2190,7 +3183,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -2200,17 +3196,29 @@
         "normalize-package-data": {
           "version": "2.3.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -2225,17 +3233,28 @@
         "object.omit": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -2245,7 +3264,12 @@
         "os-locale": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "execa": "^0.5.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
         },
         "p-finally": {
           "version": "1.0.0",
@@ -2260,22 +3284,37 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
         },
         "parse-glob": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -2295,7 +3334,12 @@
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "pify": {
           "version": "2.3.0",
@@ -2310,17 +3354,27 @@
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
         },
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
             }
           }
         },
@@ -2337,22 +3391,39 @@
         "randomatic": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
+          }
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
             }
           }
         },
@@ -2364,7 +3435,11 @@
         "regex-cache": {
           "version": "0.4.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
+          }
         },
         "remove-trailing-separator": {
           "version": "1.0.1",
@@ -2384,7 +3459,10 @@
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
@@ -2405,12 +3483,18 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -2441,6 +3525,14 @@
           "version": "1.2.4",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "foreground-child": "^1.3.3",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.3.3",
+            "signal-exit": "^2.0.0",
+            "which": "^1.2.4"
+          },
           "dependencies": {
             "signal-exit": {
               "version": "2.1.2",
@@ -2452,7 +3544,10 @@
         "spdx-correct": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "^1.0.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
@@ -2468,6 +3563,10 @@
           "version": "2.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^3.0.0"
+          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
@@ -2479,12 +3578,18 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
         },
         "strip-eof": {
           "version": "1.0.0",
@@ -2499,7 +3604,14 @@
         "test-exclude": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -2516,12 +3628,23 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -2534,12 +3657,19 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
+          }
         },
         "which": {
           "version": "1.2.14",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         },
         "which-module": {
           "version": "2.0.0",
@@ -2561,11 +3691,20 @@
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
             }
           }
         },
@@ -2577,7 +3716,12 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
         },
         "y18n": {
           "version": "3.2.1",
@@ -2593,6 +3737,21 @@
           "version": "8.0.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
@@ -2603,33 +3762,61 @@
               "version": "3.2.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
                 }
               }
             },
             "load-json-file": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
             },
             "path-type": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
             },
             "read-pkg": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
             },
             "read-pkg-up": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
             },
             "strip-bom": {
               "version": "3.0.0",
@@ -2639,7 +3826,10 @@
             "yargs-parser": {
               "version": "7.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
             }
           }
         },
@@ -2647,6 +3837,9 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -2677,7 +3870,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -2695,7 +3891,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2716,23 +3920,38 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
     },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0="
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
     },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2762,6 +3981,9 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2775,7 +3997,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "performance-now": {
       "version": "0.2.0",
@@ -2795,25 +4022,41 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pkg-conf": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
       "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
       "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^2.0.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -2827,19 +4070,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
     },
     "pkg-up": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
     },
     "plur": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^1.0.0"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -2895,31 +4147,54 @@
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU="
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "requires": {
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         }
       }
     },
@@ -2927,29 +4202,46 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
     },
     "registry-auth-token": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
-      "integrity": "sha1-V65nNH5z2WNF7RvAEpTHI3wCqmM="
+      "integrity": "sha1-V65nNH5z2WNF7RvAEpTHI3wCqmM=",
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI="
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "^1.0.1"
+      }
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "req-all": {
       "version": "1.0.0",
@@ -2961,7 +4253,29 @@
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -2978,6 +4292,10 @@
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
       "dependencies": {
         "resolve-from": {
           "version": "1.0.1",
@@ -2991,13 +4309,19 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
     },
     "resolve-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
       "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0"
+      }
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -3009,13 +4333,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
     },
     "roundround": {
       "version": "0.2.0",
@@ -3026,7 +4357,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -3053,7 +4387,10 @@
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY="
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "requires": {
+        "semver": "^5.0.3"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3064,7 +4401,12 @@
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
       "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -3075,7 +4417,17 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.2.tgz",
       "integrity": "sha1-xDqcVw8yuqwRWVBc/u0ZEIhV34k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -3097,18 +4449,27 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "^1.0.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -3130,6 +4491,17 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jodid25519": "^1.0.0",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      },
       "dependencies": {
         "asn1": {
           "version": "0.2.3",
@@ -3146,7 +4518,11 @@
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4="
+      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^3.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3156,13 +4532,19 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -3174,6 +4556,9 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      },
       "dependencies": {
         "get-stdin": {
           "version": "4.0.1",
@@ -3197,12 +4582,23 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      }
     },
     "term-size": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co="
+      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+      "requires": {
+        "execa": "^0.4.0"
+      }
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -3236,7 +4632,10 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "^1.4.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -3266,7 +4665,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.3",
@@ -3283,7 +4685,10 @@
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo="
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -3293,18 +4698,34 @@
     "update-notifier": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
-      "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k="
+      "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
+      "requires": {
+        "boxen": "^1.0.0",
+        "chalk": "^1.0.0",
+        "configstore": "^3.0.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "lazy-req": "^2.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
     },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3321,12 +4742,19 @@
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "visit-values": {
       "version": "2.0.0",
@@ -3336,22 +4764,36 @@
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "requires": {
+        "string-width": "^1.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -3365,16 +4807,28 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -3388,24 +4842,43 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.3.tgz",
-      "integrity": "sha1-gx3SLUkb3BNRgLuZag6z+L9Yd5E="
+      "integrity": "sha1-gx3SLUkb3BNRgLuZag6z+L9Yd5E=",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
     },
     "write-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.0.0.tgz",
       "integrity": "sha1-Dq7Jgfz5KI28KAbL0m4Gq5vcpO0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.1",
+        "pify": "^2.0.0",
+        "sort-keys": "^1.1.1",
+        "write-file-atomic": "^1.1.2"
+      }
     },
     "write-pkg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-2.1.0.tgz",
       "integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sort-keys": "^1.1.2",
+        "write-json-file": "^2.0.0"
+      }
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -3417,6 +4890,33 @@
       "resolved": "https://registry.npmjs.org/xo/-/xo-0.18.2.tgz",
       "integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
       "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "debug": "^2.2.0",
+        "deep-assign": "^1.0.0",
+        "eslint": "^3.18.0",
+        "eslint-config-xo": "^0.18.0",
+        "eslint-formatter-pretty": "^1.0.0",
+        "eslint-plugin-ava": "^4.2.0",
+        "eslint-plugin-import": "^2.0.0",
+        "eslint-plugin-no-use-extend-native": "^0.3.2",
+        "eslint-plugin-promise": "^3.4.0",
+        "eslint-plugin-unicorn": "^2.1.0",
+        "get-stdin": "^5.0.0",
+        "globby": "^6.0.0",
+        "has-flag": "^2.0.0",
+        "ignore": "^3.2.6",
+        "lodash.isequal": "^4.4.0",
+        "meow": "^3.4.2",
+        "multimatch": "^2.1.0",
+        "path-exists": "^3.0.0",
+        "pkg-conf": "^2.0.0",
+        "resolve-cwd": "^1.0.0",
+        "resolve-from": "^2.0.0",
+        "slash": "^1.0.0",
+        "update-notifier": "^2.1.0",
+        "xo-init": "^0.5.0"
+      },
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
@@ -3437,36 +4937,70 @@
       "resolved": "https://registry.npmjs.org/xo-init/-/xo-init-0.5.0.tgz",
       "integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
       "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "execa": "^0.5.0",
+        "minimist": "^1.1.3",
+        "path-exists": "^3.0.0",
+        "read-pkg-up": "^2.0.0",
+        "the-argv": "^1.0.0",
+        "write-pkg": "^2.0.0"
+      },
       "dependencies": {
         "execa": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
           "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
         },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
         },
         "path-exists": {
           "version": "3.0.0",
@@ -3484,19 +5018,31 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -3526,36 +5072,81 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
       "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+      "requires": {
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
+      },
       "dependencies": {
         "execa": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY="
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
         },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg="
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
         },
         "os-locale": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ="
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "requires": {
+            "execa": "^0.5.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
         },
         "path-key": {
           "version": "2.0.1",
@@ -3565,17 +5156,29 @@
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM="
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "^2.0.0"
+          }
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg="
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4="
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -3590,7 +5193,10 @@
         "yargs-parser": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k="
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "furthermore",
   "description": "add and set etcd keys conveniently",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": "C J Silverio <ceej@npmjs.com>",
   "bin": {
     "furthermore": "cli.js",


### PR DESCRIPTION
Fix the grep command.

Before:
```
$ npx fm --env production grep  scoped-public-skimdb
node_modules/.bin/fm grep <pattern>

Options:
  --env, -e  which etcd host group to use                   [default: "default"]
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]

need a pattern to grep for e.g. foo or /foo/
```